### PR TITLE
ENH: replace continuumio image with pytorch

### DIFF
--- a/pypackage_generator.sh
+++ b/pypackage_generator.sh
@@ -380,7 +380,7 @@ docker_python() {
 
 docker_pytorch() {
     printf "%b\n" \
-        "FROM continuumio/anaconda3" \
+        "FROM pytorch/pytorch" \
         "" \
         "WORKDIR /usr/src/${MAIN_DIR}" \
         "" \


### PR DESCRIPTION
Anaconda chose to base off of Alpine to reduce image size resulting in
errors related to using sh in lieu of bash.